### PR TITLE
XY & XYZ: Fix deprecated-copy warnings for GCC 10 and eliminate boost.

### DIFF
--- a/evolvotron/libfunction/xy.h
+++ b/evolvotron/libfunction/xy.h
@@ -32,7 +32,7 @@
 class XY
 {
  protected:
-  boost::array<real,2> _rep;
+  real _rep[2];
 
  public:
 
@@ -63,13 +63,6 @@ class XY
   XY()
     {}
 
-  //! Copy constructor.
-  XY(const XY& v)
-    {
-      _rep[0]=v._rep[0];
-      _rep[1]=v._rep[1];
-    }
-  
   //! Initialise from separate components.
   XY(real vx,real vy)
     {

--- a/evolvotron/libfunction/xyz.h
+++ b/evolvotron/libfunction/xyz.h
@@ -36,7 +36,7 @@ class Random01;
 class XYZ
 {
  protected:
-  boost::array<real,3> _rep;
+  real _rep[3];
 
  public:
 
@@ -78,14 +78,6 @@ class XYZ
    */
   XYZ()
     {}
-
-  //! Copy constructor.
-  XYZ(const XYZ& v)
-    {
-      _rep[0]=v._rep[0];
-      _rep[1]=v._rep[1];
-      _rep[2]=v._rep[2];
-    }
 
   //! Initialise from an XY and a z component.
   XYZ(const XY& p,real vz)


### PR DESCRIPTION
Remove copy constructor to quiet many of these messages:

  warning: implicitly-declared
  ‘constexpr XYZ& XYZ::operator=(const XYZ&)’ is deprecated